### PR TITLE
Make HTTP Timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ $ SB_HOST="http://redis-service-broker.service.dc1.consul:3000/" SB_USERNAME="ad
 | SB_USERNAME | The username |
 | SB_PASSWORD | The password |
 | SB_SKIP_SSL_VERIFY | If true SSL verification is skipped |
+| SB_TIMEOUT | HTTP Timeout in seconds (default: 15) |
 
 
 ## Logging

--- a/sbcli/sbclient.go
+++ b/sbcli/sbclient.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -47,7 +48,13 @@ func (s *SBClient) TestConnection() error {
 		fmt.Printf("\tTest host: %s\n", s.Host)
 	}
 
-	client := http.Client{Timeout: 15 * time.Second}
+	timeout := 15
+	val, present := os.LookupEnv("SB_TIMEOUT")
+	if present == true {
+		timeout, _ = strconv.Atoi(val)
+	}
+
+	client := http.Client{Timeout: time.Duration(timeout) * time.Second}
 
 	if s.isHttps() {
 		client.Transport = &http.Transport{
@@ -129,7 +136,13 @@ func (s *SBClient) getResultFromBroker(url string, method string, jsonStr string
 		fmt.Printf("\tBody:\n\t%s\n", jsonStr)
 	}
 
-	client := http.Client{Timeout: 15 * time.Second}
+	timeout := 15
+	val, present := os.LookupEnv("SB_TIMEOUT")
+	if present == true {
+		timeout, _ = strconv.Atoi(val)
+	}
+
+	client := http.Client{Timeout: time.Duration(timeout) * time.Second}
 
 	if s.isHttps() {
 		if os.Getenv("SB_TRACE") == "ON" {


### PR DESCRIPTION
Currently HTTP Timeout is hardcoded to 15s which is easily reached in environment with a couple hundred service instance. The adjustments of this PR make it possible to configure the HTTP Timeout via an environment variable.

Fixes https://github.com/phartz/service-broker-cli/issues/16